### PR TITLE
if attribute name contains a space add slashe

### DIFF
--- a/src/bootstrap-table-filter.js
+++ b/src/bootstrap-table-filter.js
@@ -476,7 +476,11 @@
 
     BootstrapTableFilter.prototype.disableFilter = function(field) {
         var filter = this.getFilter(field);
-        this.$buttonList.find('[data-filter-field=' + field + '] input[type=checkbox]').prop('checked', false);
+        var fieldWithSlashes = field;
+        if (/\s/.test(field)) { // if field string contains a space character
+            fieldWithSlashes = field.replace(/ /g,"\\ ");
+        }
+        this.$buttonList.find('[data-filter-field=' + fieldWithSlashes + '] input[type=checkbox]').prop('checked', false);
         filter.enabled = false;
         if (filter.$dropdown) {
             filter.$dropdown.remove();


### PR DESCRIPTION
If `field` string contains spaces, jquery throws error. One solution is replacing spaces with slashes. More info [SO](http://stackoverflow.com/a/5287143/968379)